### PR TITLE
Env vars support

### DIFF
--- a/src/Templater.Tests/EnvironmentVariableReplacementTests.cs
+++ b/src/Templater.Tests/EnvironmentVariableReplacementTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Templater.Tests
+{
+	[TestFixture]
+	public class EnvironmentVariableReplacementTests
+	{
+		[Test]
+		public void It_can_get_list_of_tokens_from_input_text()
+		{
+			var inputText = "Example [%SomeKey%] \r\n" +
+				"Another example [%AnotherKey%] \r\n" +
+				"Another example [%AnUnmatchedKey%] \r\n" +
+				"You can't match this [%NoMatch";
+
+			var actual = GetTokens(inputText).ToArray();
+
+			Assert.That(actual.Length, Is.EqualTo(3));
+			Assert.That(actual[0], Is.EqualTo("SomeKey"));
+			Assert.That(actual[1], Is.EqualTo("AnotherKey"));
+			Assert.That(actual[2], Is.EqualTo("AnUnmatchedKey"));
+		}
+
+		private IEnumerable<string> GetTokens(string input)
+		{
+			var matches = Regex.Matches(input, @"\[\%(.+?)\%\]")
+				.Cast<Match>();
+			return matches.Select(x=>x.Groups[1].Value);
+		}
+	}
+}

--- a/src/Templater.Tests/EnvironmentVariableReplacementTests.cs
+++ b/src/Templater.Tests/EnvironmentVariableReplacementTests.cs
@@ -14,8 +14,8 @@ namespace Templater.Tests
 		[SetUp]
 		public void Given_enviroment_variables_exist()
 		{
-			System.Environment.SetEnvironmentVariable("SomeKey", "I replaced SomeKey");
-			System.Environment.SetEnvironmentVariable("AnotherKey", "I replaced AnotherKey");
+			System.Environment.SetEnvironmentVariable("SomeKey_LOCAL", "I replaced SomeKey");
+			System.Environment.SetEnvironmentVariable("AnotherKey_LOCAL", "I replaced AnotherKey");
 		}
 
 		[Test]
@@ -32,7 +32,7 @@ namespace Templater.Tests
 		[Test]
 		public void It_can_swap_out_enviroment_variables_based_on_list_of_tokens()
 		{
-			var actual = EnvironmentVariableReplacer.SwapEnvironmentVariables(INPUT_TEXT);
+			var actual = EnvironmentVariableReplacer.SwapEnvironmentVariables(INPUT_TEXT, new Environment() { Name="local" });
 
 			var expected = "Example I replaced SomeKey \r\n" +
 				"Another example I replaced AnotherKey \r\n" +
@@ -45,8 +45,8 @@ namespace Templater.Tests
 		[TearDown]
 		public void Remove_enviroment_variables()
 		{
-			System.Environment.SetEnvironmentVariable("SomeKey", null);
-			System.Environment.SetEnvironmentVariable("AnotherKey", null);
+			System.Environment.SetEnvironmentVariable("SomeKey_LOCAL", null);
+			System.Environment.SetEnvironmentVariable("AnotherKey_LOCAL", null);
 		}
 	}
 }

--- a/src/Templater.Tests/EnvironmentVariableReplacementTests.cs
+++ b/src/Templater.Tests/EnvironmentVariableReplacementTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -8,20 +9,50 @@ namespace Templater.Tests
 	[TestFixture]
 	public class EnvironmentVariableReplacementTests
 	{
+		private const string INPUT_TEXT = "Example [%SomeKey%] \r\n" +
+			"Another example [%AnotherKey%] \r\n" +
+			"Another example [%AnUnmatchedKey%] \r\n" +
+			"You can't match this [%NoMatch";
+
 		[Test]
 		public void It_can_get_list_of_tokens_from_input_text()
 		{
-			var inputText = "Example [%SomeKey%] \r\n" +
-				"Another example [%AnotherKey%] \r\n" +
-				"Another example [%AnUnmatchedKey%] \r\n" +
-				"You can't match this [%NoMatch";
-
-			var actual = GetTokens(inputText).ToArray();
+			var actual = GetTokens(INPUT_TEXT).ToArray();
 
 			Assert.That(actual.Length, Is.EqualTo(3));
 			Assert.That(actual[0], Is.EqualTo("SomeKey"));
 			Assert.That(actual[1], Is.EqualTo("AnotherKey"));
 			Assert.That(actual[2], Is.EqualTo("AnUnmatchedKey"));
+		}
+
+		[Test]
+		public void It_can_swap_out_enviroment_variables_based_on_list_of_tokens()
+		{
+			System.Environment.SetEnvironmentVariable("SomeKey", "I replaced SomeKey");
+			System.Environment.SetEnvironmentVariable("AnotherKey", "I replaced AnotherKey");
+
+			var actual = SwapEnvironmentVariables(INPUT_TEXT);
+
+			var expected = "Example I replaced SomeKey \r\n" +
+				"Another example I replaced AnotherKey \r\n" +
+				"Another example [%AnUnmatchedKey%] \r\n" +
+				"You can't match this [%NoMatch";
+
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+
+		private object SwapEnvironmentVariables(string input)
+		{
+			foreach (var token in GetTokens(input))
+			{
+				var environmentVariable = System.Environment.GetEnvironmentVariable(token);
+				if (!string.IsNullOrEmpty(environmentVariable))
+				{
+					input = input.ReplaceKey(token, environmentVariable);
+				}
+			}
+
+			return input;
 		}
 
 		private IEnumerable<string> GetTokens(string input)

--- a/src/Templater.Tests/SettingsReplacerTests.cs
+++ b/src/Templater.Tests/SettingsReplacerTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 
 namespace Templater.Tests
-{
+{ 
 	[TestFixture]
 	public class SettingsReplacerTests
 	{
@@ -91,6 +91,16 @@ namespace Templater.Tests
 			}
 
 			Assert.Fail();
+		}
+
+		[Test]
+		[Ignore("Not Implemented Yet")]
+		public void It_checks_env_var_first()
+		{
+			System.Environment.SetEnvironmentVariable("SomeKey", "I am some key");
+
+			var replace = _replacer.Replace("Example [%SomeKey%]", null, new Environment { Name = "local" });
+
 		}
 	}
 }

--- a/src/Templater.Tests/SettingsReplacerTests.cs
+++ b/src/Templater.Tests/SettingsReplacerTests.cs
@@ -100,6 +100,8 @@ namespace Templater.Tests
 
 			var replace = _replacer.Replace("Example [%EnvironmentVariableKey%]", null, new Environment { Name = "local" });
 
+			Assert.That(replace, Is.EqualTo("Example I am some key"));
+
 			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey_LOCAL", null);
 		}
 	}

--- a/src/Templater.Tests/SettingsReplacerTests.cs
+++ b/src/Templater.Tests/SettingsReplacerTests.cs
@@ -96,11 +96,11 @@ namespace Templater.Tests
 		[Test]
 		public void It_checks_env_var_first()
 		{
-			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey", "I am some key");
+			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey_LOCAL", "I am some key");
 
 			var replace = _replacer.Replace("Example [%EnvironmentVariableKey%]", null, new Environment { Name = "local" });
 
-			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey", null);
+			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey_LOCAL", null);
 		}
 	}
 }

--- a/src/Templater.Tests/SettingsReplacerTests.cs
+++ b/src/Templater.Tests/SettingsReplacerTests.cs
@@ -94,13 +94,13 @@ namespace Templater.Tests
 		}
 
 		[Test]
-		[Ignore("Not Implemented Yet")]
 		public void It_checks_env_var_first()
 		{
-			System.Environment.SetEnvironmentVariable("SomeKey", "I am some key");
+			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey", "I am some key");
 
-			var replace = _replacer.Replace("Example [%SomeKey%]", null, new Environment { Name = "local" });
+			var replace = _replacer.Replace("Example [%EnvironmentVariableKey%]", null, new Environment { Name = "local" });
 
+			System.Environment.SetEnvironmentVariable("EnvironmentVariableKey", null);
 		}
 	}
 }

--- a/src/Templater.Tests/Templater.Tests.csproj
+++ b/src/Templater.Tests/Templater.Tests.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EnvironmentVariableReplacementTests.cs" />
     <Compile Include="FileTests.cs" />
     <Compile Include="FileWrapperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Templater/EnvironmentVariableReplacer.cs
+++ b/src/Templater/EnvironmentVariableReplacer.cs
@@ -1,3 +1,4 @@
+using log4net;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -6,11 +7,11 @@ namespace Templater
 {
 	public static class EnvironmentVariableReplacer
 	{
-		public static string SwapEnvironmentVariables(string input)
+		public static string SwapEnvironmentVariables(string input, Environment environment)
 		{
 			foreach (var token in GetTokens(input))
 			{
-				var environmentVariable = System.Environment.GetEnvironmentVariable(token);
+				var environmentVariable = System.Environment.GetEnvironmentVariable(FormEnvVarKey(token, environment));
 				if (!string.IsNullOrEmpty(environmentVariable))
 				{
 					input = input.ReplaceKey(token, environmentVariable);
@@ -25,6 +26,16 @@ namespace Templater
 			var matches = Regex.Matches(input, @"\[\%(.+?)\%\]")
 				.Cast<Match>();
 			return matches.Select(x=>x.Groups[1].Value);
+		}
+
+		private static string FormEnvVarKey(string token, Environment environment)
+		{
+			if (environment != null && !string.IsNullOrEmpty(environment.Name))
+			{
+				return string.Format("{0}_{1}", token, environment.Name);
+			}
+
+			return token;
 		}
 	}
 }

--- a/src/Templater/EnvironmentVariableReplacer.cs
+++ b/src/Templater/EnvironmentVariableReplacer.cs
@@ -7,14 +7,18 @@ namespace Templater
 {
 	public static class EnvironmentVariableReplacer
 	{
+		private static readonly ILog _log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
 		public static string SwapEnvironmentVariables(string input, Environment environment)
 		{
 			foreach (var token in GetTokens(input))
 			{
-				var environmentVariable = System.Environment.GetEnvironmentVariable(FormEnvVarKey(token, environment));
+				var environmentVariableKey = FormEnvVarKey(token, environment);
+				var environmentVariable = System.Environment.GetEnvironmentVariable(environmentVariableKey);
 				if (!string.IsNullOrEmpty(environmentVariable))
 				{
 					input = input.ReplaceKey(token, environmentVariable);
+					_log.InfoFormat("Replacing setting from env variable - [%{0}%] - {1}", token, environmentVariableKey);
 				}
 			}
 

--- a/src/Templater/EnvironmentVariableReplacer.cs
+++ b/src/Templater/EnvironmentVariableReplacer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Templater
+{
+	public static class EnvironmentVariableReplacer
+	{
+		public static string SwapEnvironmentVariables(string input)
+		{
+			foreach (var token in GetTokens(input))
+			{
+				var environmentVariable = System.Environment.GetEnvironmentVariable(token);
+				if (!string.IsNullOrEmpty(environmentVariable))
+				{
+					input = input.ReplaceKey(token, environmentVariable);
+				}
+			}
+
+			return input;
+		}
+
+		public static IEnumerable<string> GetTokens(string input)
+		{
+			var matches = Regex.Matches(input, @"\[\%(.+?)\%\]")
+				.Cast<Match>();
+			return matches.Select(x=>x.Groups[1].Value);
+		}
+	}
+}

--- a/src/Templater/SettingsReplacer.cs
+++ b/src/Templater/SettingsReplacer.cs
@@ -21,7 +21,7 @@ namespace Templater
 			globals = globals ?? new Environment();
 			UnusedKeys = new HashSet<string>();
 
-			input = EnvironmentVariableReplacer.SwapEnvironmentVariables(input);
+			input = EnvironmentVariableReplacer.SwapEnvironmentVariables(input, environment);
 
 			foreach (var key in environment.Values.Keys.Where(key => !input.ContainsKey(key)).Where(key => !UnusedKeys.Contains(key.ToLower())))
 				UnusedKeys.Add(key.ToLower());

--- a/src/Templater/SettingsReplacer.cs
+++ b/src/Templater/SettingsReplacer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
@@ -21,6 +20,8 @@ namespace Templater
 		{
 			globals = globals ?? new Environment();
 			UnusedKeys = new HashSet<string>();
+
+			input = EnvironmentVariableReplacer.SwapEnvironmentVariables(input);
 
 			foreach (var key in environment.Values.Keys.Where(key => !input.ContainsKey(key)).Where(key => !UnusedKeys.Contains(key.ToLower())))
 				UnusedKeys.Add(key.ToLower());

--- a/src/Templater/Templater.csproj
+++ b/src/Templater/Templater.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.cs" />
+    <Compile Include="EnvironmentVariableReplacer.cs" />
     <Compile Include="FileWrapper.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR adds the ability for templater to check environment variables for values prior to checking your settings/json files.

This in turn allows a user to encrpyt and store sensitive credentials in Teamcity and pass them in at build time (i.e. when the env specific config files are generated), nd prevents the need for them to be stored as plain text in github  / gitorious.