### PR TITLE
Adds -e --environment parameter that allows build for specified environment

### DIFF
--- a/Templater.sln
+++ b/Templater.sln
@@ -7,12 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Templater", "src\Templater\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Templater.Tests", "src\Templater.Tests\Templater.Tests.csproj", "{76D87D9A-2072-486E-85DB-EAEC2D0B1B06}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{EB515AE8-6688-4F61-881E-443979735D87}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Templater.Tests/ConsoleOptionsTests.cs
+++ b/src/Templater.Tests/ConsoleOptionsTests.cs
@@ -1,0 +1,50 @@
+﻿using NUnit.Framework;
+using System;
+using CommandLine;
+
+namespace Templater.Tests
+{
+	public class ConsoleOptionsTests
+	{
+		private Options _options;
+
+		[SetUp]
+		public void Given_all_args_specified()
+		{
+			_options = new Options();
+			var args = new[] {"-d", "src", "-g", "settings.json", "-e", "local"};
+			Parser.Default.ParseArguments(args, _options);
+		}
+
+		[Test]
+		public void the_help_text_is_valid()
+		{
+			var helptext = _options.Help();
+			Console.WriteLine(helptext);
+			Assert.That(helptext, Is.StringContaining("-d, --directory"));
+			Assert.That(helptext, Is.StringContaining("Required. The working directory to recursively scan"));
+			Assert.That(helptext, Is.StringContaining("-g, --global-settings"));
+			Assert.That(helptext, Is.StringContaining("Path to a global settings json file"));
+			Assert.That(helptext, Is.StringContaining("-e, --environment"));
+			Assert.That(helptext, Is.StringContaining("(Default: all) Run for a specific environment only"));
+		}
+
+		[Test]
+		public void the_directory_is_specified()
+		{
+			Assert.That(_options.Directory, Is.EqualTo("src"));
+		}
+
+		[Test]
+		public void the_globalsettings_param_is_specified()
+		{
+			Assert.That(_options.GlobalSettingsPath, Is.EqualTo("settings.json"));
+		}
+
+		[Test]
+		public void the_environment_param_is_specified()
+		{
+			Assert.That(_options.RunEnvironment, Is.EqualTo("local"));
+		}
+	}
+}

--- a/src/Templater.Tests/SettingsWriterTests.cs
+++ b/src/Templater.Tests/SettingsWriterTests.cs
@@ -36,35 +36,5 @@ namespace Templater.Tests
 			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.uat.config", null));
 			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.prod.config", null));
 		}
-
-		[Test]
-		public void It_writes_for_specific_environment_if_specified()
-		{
-			var files = MockRepository.GenerateStub<IFileWrapper>();
-			var replacer = MockRepository.GenerateStub<ISettingsReplacer>();
-
-			var writer = new SettingsWriter(files, replacer);
-			var settings = new Settings
-				{
-					Environments = new List<Environment>
-						{
-							new Environment
-								{
-									Name = "uat",
-									FileName = "web.uat.config",
-								},
-							new Environment
-								{
-									Name = "prod",
-									FileName = "web.prod.config",
-								},
-						}
-				};
-
-			writer.Write(@"C:\web.template.config", new Settings(), settings);
-
-			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.uat.config", null));
-			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.prod.config", null));
-		}
 	}
 }

--- a/src/Templater.Tests/SettingsWriterTests.cs
+++ b/src/Templater.Tests/SettingsWriterTests.cs
@@ -36,5 +36,35 @@ namespace Templater.Tests
 			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.uat.config", null));
 			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.prod.config", null));
 		}
+
+		[Test]
+		public void It_writes_for_specific_environment_if_specified()
+		{
+			var files = MockRepository.GenerateStub<IFileWrapper>();
+			var replacer = MockRepository.GenerateStub<ISettingsReplacer>();
+
+			var writer = new SettingsWriter(files, replacer);
+			var settings = new Settings
+				{
+					Environments = new List<Environment>
+						{
+							new Environment
+								{
+									Name = "uat",
+									FileName = "web.uat.config",
+								},
+							new Environment
+								{
+									Name = "prod",
+									FileName = "web.prod.config",
+								},
+						}
+				};
+
+			writer.Write(@"C:\web.template.config", new Settings(), settings);
+
+			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.uat.config", null));
+			files.AssertWasCalled(x => x.WriteAllText(@"C:\web.prod.config", null));
+		}
 	}
 }

--- a/src/Templater.Tests/SpecificEnvironmentFilterTests.cs
+++ b/src/Templater.Tests/SpecificEnvironmentFilterTests.cs
@@ -37,6 +37,13 @@ namespace Templater.Tests
 		}
 
 		[Test]
+		public void When_null_should_contain_all_environment()
+		{
+			var filteredSettings = _settings.ApplySpecificEnvironmentFilter(null);
+			Assert.That(filteredSettings.Environments.Count, Is.EqualTo(3));
+		}
+
+		[Test]
 		public void When_invalid_environment_specified_then_throws_error()
 		{
 			var exception = Assert.Throws<Exception>(() => _settings.ApplySpecificEnvironmentFilter("deepspace"));

--- a/src/Templater.Tests/SpecificEnvironmentFilterTests.cs
+++ b/src/Templater.Tests/SpecificEnvironmentFilterTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using System;
+
+namespace Templater.Tests
+{
+	public class SpecificEnvironmentFilterTests
+	{
+		private Settings _settings;
+
+		[SetUp]
+		public void Given_a_settings_file_containing_environments()
+		{
+			_settings = new Settings()
+			{
+				Environments = new System.Collections.Generic.List<Environment>()
+				{
+					new Environment() {Name = "local"},
+					new Environment() {Name = "uat"},
+					new Environment() {Name = "prod"}
+				}
+			};
+		}
+
+		[Test]
+		public void When_filter_specified_then_should_only_contain_correct_environment()
+		{
+			var filteredSettings = _settings.ApplySpecificEnvironmentFilter("local");
+			Assert.That(filteredSettings.Environments.Count, Is.EqualTo(1));
+			Assert.That(filteredSettings.Environments[0].Name, Is.EqualTo("local"));
+		}
+
+		[Test]
+		public void When_all_specified_should_contain_all_environment()
+		{
+			var filteredSettings = _settings.ApplySpecificEnvironmentFilter("all");
+			Assert.That(filteredSettings.Environments.Count, Is.EqualTo(3));
+		}
+
+		[Test]
+		public void When_invalid_environment_specified_then_throws_error()
+		{
+			var exception = Assert.Throws<Exception>(() => _settings.ApplySpecificEnvironmentFilter("deepspace"));
+			Assert.That(exception.Message, Is.EqualTo("Invalid environment specified: deepspace"));
+		}
+	}
+}

--- a/src/Templater.Tests/Templater.Tests.csproj
+++ b/src/Templater.Tests/Templater.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="SettingsReaderTests.cs" />
     <Compile Include="SettingsReplacerTests.cs" />
     <Compile Include="SettingsWriterTests.cs" />
+    <Compile Include="SpecificEnvironmentFilterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/src/Templater.Tests/Templater.Tests.csproj
+++ b/src/Templater.Tests/Templater.Tests.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -46,6 +50,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConsoleOptionsTests.cs" />
     <Compile Include="EnvironmentVariableReplacementTests.cs" />
     <Compile Include="FileTests.cs" />
     <Compile Include="FileWrapperTests.cs" />

--- a/src/Templater.Tests/packages.config
+++ b/src/Templater.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />

--- a/src/Templater/App.cs
+++ b/src/Templater/App.cs
@@ -34,7 +34,10 @@ namespace Templater
 				{
 					_log.InfoFormat("Processing - {0}", file.TemplatePath);
 
-					var settings = reader.Read(file.SettingsPath);
+					var settings = reader
+						.Read(file.SettingsPath)
+						.ApplySpecificEnvironmentFilter(options.RunEnvironment);
+
 					writer.Write(file.TemplatePath, globals, settings);
 				}
 

--- a/src/Templater/Options.cs
+++ b/src/Templater/Options.cs
@@ -11,6 +11,9 @@ namespace Templater
 		[Option('g', "global-settings", Required = false, HelpText = "Path to a global settings json file")]
 		public string GlobalSettingsPath { get; set; }
 
+		[Option('e', "environment", Required = false, HelpText = "Run for a specific environment only - defaults to all", DefaultValue="all")]
+		public string RunEnvironment { get; set; }
+
 		[HelpOption]
 		public string Help()
 		{

--- a/src/Templater/SettingsFilters.cs
+++ b/src/Templater/SettingsFilters.cs
@@ -6,7 +6,7 @@ namespace Templater
 	{
 		public static Settings ApplySpecificEnvironmentFilter(this Settings settings, string environment)
 		{
-			if (environment.ToLower() != "all")
+			if (environment != null && environment.ToLower() != "all")
 			{
 				var chosenSetting = settings.Environments.FindAll(x => x.Name == environment.ToLower());
 				if (chosenSetting.Count < 1)

--- a/src/Templater/SettingsFilters.cs
+++ b/src/Templater/SettingsFilters.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Templater
+{
+	public static class SettingsFilters
+	{
+		public static Settings ApplySpecificEnvironmentFilter(this Settings settings, string environment)
+		{
+			if (environment.ToLower() != "all")
+			{
+				var chosenSetting = settings.Environments.FindAll(x => x.Name == environment.ToLower());
+				if (chosenSetting.Count < 1)
+				{
+					throw new Exception(string.Format("Invalid environment specified: {0}", environment));
+				}
+				settings.Environments = chosenSetting;
+			}
+			return settings;
+		}
+	}
+}

--- a/src/Templater/Templater.csproj
+++ b/src/Templater/Templater.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Options.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="SettingsFilters.cs" />
     <Compile Include="SettingsTokensNotReplacedException.cs" />
     <Compile Include="SettingsReader.cs" />
     <Compile Include="SettingsReplacer.cs" />


### PR DESCRIPTION
This adds the following:

* `-e --environment` parameter
* extra tests around `CommandLineParser` options

Allows a user to specify the exact environment that they need to run Templater for. This is great for local builds as developer only needs local settings and prevents the need for local dev machine to access deployment secrets unless absolutely necessary.